### PR TITLE
Use a much better multiply algorithm which takes advantage of modern CPUs

### DIFF
--- a/uint128_t.include
+++ b/uint128_t.include
@@ -264,18 +264,23 @@ class uint128_t{
             *this = *this - rhs;
             return *this;
         }
-
-        uint128_t operator*(const uint128_t & rhs) const;
+        // Note: _UINT128_T_MULTI_TARGET is for disabling SSE2 and switching to ARM mode from Thumb to greatly
+        // improve the performance.
+private:
+        // XXX: make this public?
+        _UINT128_T_MULT_TARGET static uint64_t multlong64(uint64_t lhs, uint64_t rhs, uint64_t *high);
+public:
+        _UINT128_T_MULT_TARGET uint128_t operator*(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        uint128_t operator*(const T & rhs) const{
+        _UINT128_T_MULT_TARGET uint128_t operator*(const T & rhs) const{
             return *this * uint128_t(rhs);
         }
 
-        uint128_t & operator*=(const uint128_t & rhs);
+        _UINT128_T_MULT_TARGET uint128_t & operator*=(const uint128_t & rhs);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        uint128_t & operator*=(const T & rhs){
+        _UINT128_T_MULT_TARGET uint128_t & operator*=(const T & rhs){
             *this = *this * uint128_t(rhs);
             return *this;
         }

--- a/uint128_t_config.include
+++ b/uint128_t_config.include
@@ -15,5 +15,54 @@
     #define _UINT128_T_EXPORT __attribute__((visibility("default")))
     #define _UINT128_T_IMPORT __attribute__((visibility("default")))
   #endif
+
+  // Multiply stuff. The algorithm is usually pretty efficient on its own, but we can do better.
+  // Notably this includes using target intrinsics and switching to ARM mode on Thumb-1 targets.
+
+  // Portable grade school long multiply
+  #define _UINT128_T_MULT_PORTABLE 0
+  // _umul128
+  #define _UINT128_T_MULT_MSVC 1
+  // __uint128_t
+  #define _UINT128_T_MULT_GCC 2
+
+  #ifndef _UINT128_T_MULT_TYPE
+    #if defined(_MSC_VER) && (defined(_M_IX64) || defined(_M_AMD64))
+      #define _UINT128_T_MULT_TYPE _UINT128_T_MULT_MSVC
+    // Clang defines __uint128_t on WASM and asm.js even though it has to use builtins for multiplication.
+    // As a result, the algorithm is slower than it would be if it was done manually.
+    #elif defined(__GNUC__) && defined(__SIZEOF_INT128__) && !defined(__wasm__) && !defined(__asmjs__)
+      #define _UINT128_T_MULT_TYPE _UINT128_T_MULT_GCC
+    #else
+      #define _UINT128_T_MULT_TYPE _UINT128_T_MULT_PORTABLE
+    #endif
+  #endif
+
+  // Some feature flags to optimize the manual algorithm.
+  #if defined(__GNUC__) && _UINT128_T_MULT_TYPE == _UINT128_T_MULT_PORTABLE
+    // GCC for x86 loves to use SSE2 in the multiply code, but it is inefficient because it uses shifts and shuffles which aren't 'free'
+    // like normal register swapping. Clang doesn't need this flag, as it never uses this.
+
+    #if !defined(__clang__) && defined(__SSE2__)
+      #define _UINT128_T_MULT_TARGET __attribute__((__target__("no-sse2")))
+
+    // In Thumb-1, the multiply algorithm is heavily crippled because the powerful UMULL, UMLAL, and UMAAL are inaccesible.
+    // Even if reading 32-bit instructions is slower, it is almost always faster to switch to ARM mode here.
+    // If you are compiling for the M profile and this is falsely being triggered, define _UINT128_T_FORCE_THUMB or use the
+    // correct -march flag.
+    //
+    // Note: Clang sometimes emits warnings like this:
+    //    '+soft-float-abi' is not a recognized feature for this target (ignoring feature)
+    // These can safely be ignored.
+
+    #elif defined(__thumb__) && !defined(__thumb2__) && defined(__ARM_ARCH_ISA_ARM) && !defined(_UINT128_T_FORCE_THUMB)
+      #define _UINT128_T_MULT_TARGET __attribute__((__target__("arm")))
+    #else
+      #define _UINT128_T_MULT_TARGET
+    #endif
+  #else
+    #define _UINT128_T_MULT_TARGET
+  #endif
+
 #endif
 


### PR DESCRIPTION
This multiply algorithm is optimized for multiple platforms, 32-bit and 64-bit.

Notably, instead of doing a full 128-bit product manually, it does a 64->128 bit long multiply on the low bits followed by two normal 64-bit multiplies which are added to the high bits.

This is to take advantage of native 64-bit arithmetic, and if it is supported, compiler intrinsics/extensions which do the long multiply for us.

This will use [`_umul128`](https://docs.microsoft.com/en-us/cpp/intrinsics/umul128?view=vs-2019) or `__uint128_t` (except on wasm) if they are available. These will expand to the single operand `MULQ` instruction on x86_64, or `MUL` + `UMULH` on aarch64.

Otherwise, the long multiply will do a simple yet fast grade-school multiply for other targets. It is optimized to suggest the powerful `UMAAL` instruction on ARM, but it doesn't require it to be fast (really you only need long multiply + `ADC`).

Because it makes a large difference in performance, I added a check which will switch off SSE2 on GCC for x86 and attempt to switch to ARM mode on Thumb-1 targets if it is available.

Switching off SSE2 in GCC for x86 prevents a laggy partial vectorization which is detrimental to the performance (mainly because instead of switching registers we have to do `PSHUFD`, `PUNPCKLDQ`, and `PSLLQ`). Clang doesn't need this.

Switching to ARM mode instead of Thumb-1 is crucial to make this algorithm usable.

ARM is well known for its powerful multiplier, with the already-excellent `UMULL` and `UMLAL` instructions, and in ARMv6, the mighty `UMAAL` which allows a long multiply to be done in **4 instructions.**

Thumb-1 does not have access to any of these, only having a 32-bit->32-bit `MUL`. This would result in calling compiler functions for something a simple mode switch can do in a quarter of the time or less.

This will be turned off if the M profile is detected or if `_UINT128_T_FORCE_THUMB` is defined.

See the comments for more details.