### PR TITLE
Synced with calccrypto/uint256_t repo changes

### DIFF
--- a/endianness.h
+++ b/endianness.h
@@ -1,0 +1,24 @@
+#ifndef _ENDIANNESS_H_
+#define _ENDIANNESS_H_
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || \
+    defined(__BIG_ENDIAN__) ||                               \
+    defined(__ARMEB__) ||                                    \
+    defined(__THUMBEB__) ||                                  \
+    defined(__AARCH64EB__) ||                                \
+    defined(_MIBSEB) || defined(__MIBSEB) || defined(__MIBSEB__)
+#ifndef __BIG_ENDIAN__
+#define __BIG_ENDIAN__
+#endif
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || \
+    defined(__LITTLE_ENDIAN__) ||                                 \
+    defined(__ARMEL__) ||                                         \
+    defined(__THUMBEL__) ||                                       \
+    defined(__AARCH64EL__) ||                                     \
+    defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__)
+#ifndef __LITTLE_ENDIAN__
+#define __LITTLE_ENDIAN__
+#endif
+#else
+#error "I don't know what architecture this is!"
+#endif
+#endif

--- a/tests/testcases/constructor.cpp
+++ b/tests/testcases/constructor.cpp
@@ -9,7 +9,7 @@ TEST(Constructor, standard){
     EXPECT_EQ(uint128_t(), 0);
     EXPECT_EQ(value, original);
     EXPECT_EQ(uint128_t(std::move(value)), original);
-    EXPECT_EQ(value, 0);
+    EXPECT_EQ(value, 0x0123456789abcdefULL);
 }
 
 TEST(Constructor, one){

--- a/uint128_t.cpp
+++ b/uint128_t.cpp
@@ -3,23 +3,6 @@
 const uint128_t uint128_0(0);
 const uint128_t uint128_1(1);
 
-uint128_t::uint128_t()
-    : UPPER(0), LOWER(0)
-{}
-
-uint128_t::uint128_t(const uint128_t & rhs)
-    : UPPER(rhs.UPPER), LOWER(rhs.LOWER)
-{}
-
-uint128_t::uint128_t(uint128_t && rhs)
-    : UPPER(std::move(rhs.UPPER)), LOWER(std::move(rhs.LOWER))
-{
-    if (this != &rhs){
-        rhs.UPPER = 0;
-        rhs.LOWER = 0;
-    }
-}
-
 uint128_t::uint128_t(std::string & s) {
     init(s.c_str());
 }
@@ -63,22 +46,6 @@ uint8_t uint128_t::HexToInt(const char *s) const {
         ret = uint8_t(*s - 'A' + 10);
     }
     return ret;
-}
-
-uint128_t & uint128_t::operator=(const uint128_t & rhs){
-    UPPER = rhs.UPPER;
-    LOWER = rhs.LOWER;
-    return *this;
-}
-
-uint128_t & uint128_t::operator=(uint128_t && rhs){
-    if (this != &rhs){
-        UPPER = std::move(rhs.UPPER);
-        LOWER = std::move(rhs.LOWER);
-        rhs.UPPER = 0;
-        rhs.LOWER = 0;
-    }
-    return *this;
 }
 
 uint128_t::operator bool() const{

--- a/uint128_t.include
+++ b/uint128_t.include
@@ -24,10 +24,10 @@ THE SOFTWARE.
 
 With much help from Auston Sterling
 
-Thanks to Stefan Deigmüller for finding
+Thanks to Stefan DeigmÃ¼ller for finding
 a bug in operator*.
 
-Thanks to François Dessenne for convincing me
+Thanks to FranÃ§ois Dessenne for convincing me
 to do a general rewrite of this class.
 */
 
@@ -42,6 +42,8 @@ to do a general rewrite of this class.
 #include <utility>
 #include <vector>
 
+#include "endianness.h"
+
 class UINT128_T_EXTERN uint128_t;
 
 // Give uint128_t type traits
@@ -53,19 +55,29 @@ namespace std {  // This is probably not a good idea
 
 class uint128_t{
     private:
+#ifdef __BIG_ENDIAN__
         uint64_t UPPER, LOWER;
+#endif
+#ifdef __LITTLE_ENDIAN__
+        uint64_t LOWER, UPPER;
+#endif
 
     public:
         // Constructors
-        uint128_t();
-        uint128_t(const uint128_t & rhs);
-        uint128_t(uint128_t && rhs);
+        uint128_t() = default;
+        uint128_t(const uint128_t & rhs) = default;
+        uint128_t(uint128_t && rhs) = default;
         uint128_t(std::string & s);
         uint128_t(const char *s);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t(const T & rhs)
+#ifdef __BIG_ENDIAN__
             : UPPER(0), LOWER(rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(rhs), UPPER(0)
+#endif
         {
             if (std::is_signed<T>::value) {
                 if (rhs < 0) {
@@ -76,14 +88,19 @@ class uint128_t{
 
         template <typename S, typename T, typename = typename std::enable_if <std::is_integral<S>::value && std::is_integral<T>::value, void>::type>
         uint128_t(const S & upper_rhs, const T & lower_rhs)
+#ifdef __BIG_ENDIAN__
             : UPPER(upper_rhs), LOWER(lower_rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(lower_rhs), UPPER(upper_rhs)
+#endif
         {}
 
         //  RHS input args only
 
         // Assignment Operator
-        uint128_t & operator=(const uint128_t & rhs);
-        uint128_t & operator=(uint128_t && rhs);
+        uint128_t & operator=(const uint128_t & rhs) = default;
+        uint128_t & operator=(uint128_t && rhs) = default;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t & operator=(const T & rhs){


### PR DESCRIPTION
Added new changes from https://github.com/calccrypto/uint256_t:
- Made uint128_t type trivially copyable
- Added support for little endian format