### PR TITLE
Fix infinite recursion

### DIFF
--- a/uint128_t.include
+++ b/uint128_t.include
@@ -211,12 +211,12 @@ class uint128_t{
         bool operator||(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        bool operator&&(const T & rhs){
+        bool operator&&(const T & rhs) const{
             return static_cast <bool> (*this && rhs);
         }
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        bool operator||(const T & rhs){
+        bool operator||(const T & rhs) const{
             return static_cast <bool> (*this || rhs);
         }
 


### PR DESCRIPTION
If these methods are not marked const, they call themselves in their implementation rather than the const-qualified uint128_t base cases.